### PR TITLE
Drop obsolete GO15VENDOREXPERIMENT env var from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 before_script:
 script:
   - glide install
-  - GO15VENDOREXPERIMENT=1 go build $(glide novendor)
-  - GO15VENDOREXPERIMENT=1 go test $(glide novendor)
+  - go build $(glide novendor)
+  - go test $(glide novendor)
   - go vet $(glide novendor)
   - glide novendor | xargs -n1 golint


### PR DESCRIPTION
Now that Go 1.5 is gone from the build matrix, this var is no longer needed,
as it is the default behaviour in Go 1.6+.