### PR TITLE
Added DHCP Architecture Type 9

### DIFF
--- a/cmd/pixiecore-apache2/main.go
+++ b/cmd/pixiecore-apache2/main.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/pixiecore/main.go
+++ b/cmd/pixiecore/main.go
@@ -23,7 +23,7 @@ import (
 func main() {
 	cli.Ipxe[pixiecore.FirmwareX86PC] = ipxe.MustAsset("undionly.kpxe")
 	cli.Ipxe[pixiecore.FirmwareEFI32] = ipxe.MustAsset("ipxe-i386.efi")
-  cli.Ipxe[pixiecore.FirmwareEFI64] = ipxe.MustAsset("ipxe-x86_64.efi")
+	cli.Ipxe[pixiecore.FirmwareEFI64] = ipxe.MustAsset("ipxe-x86_64.efi")
 	cli.Ipxe[pixiecore.FirmwareEFIBC] = ipxe.MustAsset("ipxe-x86_64.efi")
 	cli.CLI()
 }

--- a/cmd/pixiecore/main.go
+++ b/cmd/pixiecore/main.go
@@ -23,6 +23,7 @@ import (
 func main() {
 	cli.Ipxe[pixiecore.FirmwareX86PC] = ipxe.MustAsset("undionly.kpxe")
 	cli.Ipxe[pixiecore.FirmwareEFI32] = ipxe.MustAsset("ipxe-i386.efi")
+  cli.Ipxe[pixiecore.FirmwareEFIBC] = ipxe.MustAsset("ipxe-x86_64.efi")
 	cli.Ipxe[pixiecore.FirmwareEFI64] = ipxe.MustAsset("ipxe-x86_64.efi")
 	cli.CLI()
 }

--- a/cmd/pixiecore/main.go
+++ b/cmd/pixiecore/main.go
@@ -23,7 +23,7 @@ import (
 func main() {
 	cli.Ipxe[pixiecore.FirmwareX86PC] = ipxe.MustAsset("undionly.kpxe")
 	cli.Ipxe[pixiecore.FirmwareEFI32] = ipxe.MustAsset("ipxe-i386.efi")
-  cli.Ipxe[pixiecore.FirmwareEFIBC] = ipxe.MustAsset("ipxe-x86_64.efi")
-	cli.Ipxe[pixiecore.FirmwareEFI64] = ipxe.MustAsset("ipxe-x86_64.efi")
+  cli.Ipxe[pixiecore.FirmwareEFI64] = ipxe.MustAsset("ipxe-x86_64.efi")
+	cli.Ipxe[pixiecore.FirmwareEFIBC] = ipxe.MustAsset("ipxe-x86_64.efi")
 	cli.CLI()
 }

--- a/pixiecore/cli/cli.go
+++ b/pixiecore/cli/cli.go
@@ -157,6 +157,7 @@ func serverFromFlags(cmd *cobra.Command) *pixiecore.Server {
 	}
 	if ipxeEFI64 != "" {
 		ret.Ipxe[pixiecore.FirmwareEFI64] = mustFile(ipxeEFI64)
+		ret.Ipxe[pixiecore.FirmwareEFIBC] = mustFile(ipxeEFI64)
 	}
 
 	if timestamps {

--- a/pixiecore/cli/cli.go
+++ b/pixiecore/cli/cli.go
@@ -156,10 +156,10 @@ func serverFromFlags(cmd *cobra.Command) *pixiecore.Server {
 		ret.Ipxe[pixiecore.FirmwareEFI32] = mustFile(ipxeEFI32)
 	}
 	if ipxeEFI64 != "" {
-		ret.Ipxe[pixiecore.FirmwareEFIBC] = mustFile(ipxeEFI64)
+		ret.Ipxe[pixiecore.FirmwareEFI64] = mustFile(ipxeEFI64)
 	}
 	if ipxeEFI64 != "" {
-		ret.Ipxe[pixiecore.FirmwareEFI64] = mustFile(ipxeEFI64)
+		ret.Ipxe[pixiecore.FirmwareEFIBC] = mustFile(ipxeEFI64)
 	}
 
 	if timestamps {

--- a/pixiecore/cli/cli.go
+++ b/pixiecore/cli/cli.go
@@ -156,8 +156,10 @@ func serverFromFlags(cmd *cobra.Command) *pixiecore.Server {
 		ret.Ipxe[pixiecore.FirmwareEFI32] = mustFile(ipxeEFI32)
 	}
 	if ipxeEFI64 != "" {
-		ret.Ipxe[pixiecore.FirmwareEFI64] = mustFile(ipxeEFI64)
 		ret.Ipxe[pixiecore.FirmwareEFIBC] = mustFile(ipxeEFI64)
+	}
+	if ipxeEFI64 != "" {
+		ret.Ipxe[pixiecore.FirmwareEFI64] = mustFile(ipxeEFI64)
 	}
 
 	if timestamps {

--- a/pixiecore/pixiecore.go
+++ b/pixiecore/pixiecore.go
@@ -125,15 +125,15 @@ const (
 	// Note the values match the values from RFC4578.
 	FirmwareX86PC Firmware = 0 // "Classic" x86 BIOS with PXE/UNDI support.
 	FirmwareEFI32          = 6 // 32-bit x86 processor running EFI
-	FirmwareEFIBC          = 7 // 64-bit x86 processor running EFI
-	FirmwareEFI64          = 9 // 64-bit x86 processor running EFI
+	FirmwareEFI64          = 7 // 64-bit x86 processor running EFI
+	FirmwareEFIBC          = 9 // 64-bit x86 processor running EFI
 )
 
 var fwToArch = map[Firmware]Architecture{
 	FirmwareX86PC: ArchIA32,
 	FirmwareEFI32: ArchIA32,
-	FirmwareEFIBC: ArchX64,
 	FirmwareEFI64: ArchX64,
+	FirmwareEFIBC: ArchX64,
 }
 
 // A Server boots machines using a Booter.

--- a/pixiecore/pixiecore.go
+++ b/pixiecore/pixiecore.go
@@ -125,12 +125,14 @@ const (
 	// Note the values match the values from RFC4578.
 	FirmwareX86PC Firmware = 0 // "Classic" x86 BIOS with PXE/UNDI support.
 	FirmwareEFI32          = 6 // 32-bit x86 processor running EFI
-	FirmwareEFI64          = 7 // 64-bit x86 processor running EFI
+	FirmwareEFIBC          = 7 // 64-bit x86 processor running EFI
+	FirmwareEFI64          = 9 // 64-bit x86 processor running EFI
 )
 
 var fwToArch = map[Firmware]Architecture{
 	FirmwareX86PC: ArchIA32,
 	FirmwareEFI32: ArchIA32,
+	FirmwareEFIBC: ArchX64,
 	FirmwareEFI64: ArchX64,
 }
 


### PR DESCRIPTION
By supporting Type 9 ( „EFI x86-64“ ), pixiecore can boot VMware (Fusion) EFI-Type Machines.

The const for FirmwareEFI64 has been renamed to FirmwareEFIBC ( see RFC-4578, Section 2.1 ) and FirmwareEFI64 is assign to type 9 and uses the same ipxe blob as FirmwareEFIBC.

Signed-off-by: Mathias Kaufmann <me@stei.gr>