### PR TITLE
handleBoot func should not always return StatusInternalServerError

### DIFF
--- a/pixiecore/http.go
+++ b/pixiecore/http.go
@@ -153,8 +153,11 @@ func (s *Server) handleFile(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleBooting(w http.ResponseWriter, r *http.Request) {
-	// This handler always errors out.
-	http.Error(w, "", http.StatusInternalServerError)
+	// This should not always errors out.
+	// if we send http.StatusInternalServerError iPXE will get a image not found error
+	// http.Error(w, "", http.StatusInternalServerError)
+	// return a empty commented script
+	fmt.Fprintf(w, "# Booting")
 
 	macStr := r.URL.Query().Get("mac")
 	if macStr == "" {


### PR DESCRIPTION
this causes iPXE to throw a Input/Output error (http://ipxe.org/1d0c6598) "ready": no such image

this is confusing to the end users when trying to debug booting