### PR TITLE
Fix markdown link

### DIFF
--- a/pixiecore/README.md
+++ b/pixiecore/README.md
@@ -170,9 +170,8 @@ sudo docker run \
 
 ## Demos and users
 
-Pixiecore was used alongside
-[waitron](https://github.com/jhaals/waitron) in a
-[https://youtu.be/QyGHZ2HCwqY?t=440](presentation at the OpenStack
+Pixiecore was used alongside [waitron](https://github.com/jhaals/waitron) 
+in a [presentation](https://youtu.be/QyGHZ2HCwqY?t=440) at the OpenStack 
 summit in 2016).
 
 If you use Pixiecore, we'd love to hear about it, and know more about


### PR DESCRIPTION
Small fix in the markdown syntax