### PR TITLE
Bump alpine version to 3.6

### DIFF
--- a/dockerfiles/pixiecore/Dockerfile
+++ b/dockerfiles/pixiecore/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 MAINTAINER David Anderson <dave@natulte.net>
 


### PR DESCRIPTION
Alpine 3.6 is readily available, and provides go 1.8.1