### PR TITLE
Resolves #57: Add RF_NETLINK to RestrictedAddressFamilies in SystemD unit for pixiecore

### DIFF
--- a/pixiecore/pixiecore.service
+++ b/pixiecore/pixiecore.service
@@ -26,7 +26,7 @@ ProtectControlGroups=true
 ProtectKernelModules=true
 NoNewPrivileges=true
 SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @mount @obsolete @privileged @raw-io
-RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
pixiecore cannot respond to PXE/DHCP requests otherwise.