### PR TITLE
Update versions of Ubuntu and Fedora

### DIFF
--- a/pixiecore/cli/quickcmd.go
+++ b/pixiecore/cli/quickcmd.go
@@ -148,6 +148,9 @@ func fedoraRecipe(parent *cobra.Command) {
 		"23",
 		"24",
 		"25",
+		"26",
+		"27",
+		"28",
 	}
 
 	fedoraCmd := &cobra.Command{

--- a/pixiecore/cli/quickcmd.go
+++ b/pixiecore/cli/quickcmd.go
@@ -95,6 +95,9 @@ func ubuntuRecipe(parent *cobra.Command) {
 		"xenial",
 		"yakkety",
 		"zesty",
+		"artful",
+		"bionic",
+		"cosmic",
 	}
 
 	ubuntuCmd := &cobra.Command{


### PR DESCRIPTION
This patch adds the latest release names of Ubuntu and Fedora.