### PR TITLE
Make documentation more user friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,21 @@
 [![license](https://img.shields.io/github/license/google/netboot.svg)](https://github.com/google/netboot/blob/master/LICENSE) [![CircleCI](https://img.shields.io/circleci/project/github/google/netboot.svg)](https://circleci.com/gh/google/netboot)     [![api](https://img.shields.io/badge/api-unstable-red.svg)](https://godoc.org/go.universe.tf/netboot)
 
 This repository contains Go implementations of network protocols used
-in booting machines over the network, as well as software that make
-use of those implementations.
+in booting machines over the network, as well as utilites built on top
+of these libraries.
 
 This is not an official Google project.
 
-The canonical import path for Go packages in this repository is `go.universe.tf/netboot`.
+## Programs
+
+- [Pixiecore](https://github.com/google/netboot/tree/master/pixiecore): Command line all-in-one tool for easy netbooting
 
 ## Libraries
+
+The canonical import path for Go packages in this repository is `go.universe.tf/netboot`.
 
 - [pcap](https://godoc.org/go.universe.tf/netboot/pcap): Pure Go implementation of reading and writing pcap files.
 - [dhcp4](https://godoc.org/go.universe.tf/netboot/dhcp4): DHCPv4 library providing the low-level bits of a DHCP client/server (packet marshaling, RFC-compliant packet transmission semantics).
 - [tftp](https://godoc.org/go.universe.tf/netboot/tftp): Read-only TFTP server implementation.
-- [pixiecore](https://godoc.org/go.universe.tf/netboot/pixiecore): the functionality of Pixiecore (see below), in library form. Every stability warning in this repository applies double for this package.
+- [pixiecore](https://godoc.org/go.universe.tf/netboot/pixiecore): Go library for Pixiecore tool functionality. Every stability warning in this repository applies double for this package.
 
-## Programs
-
-- [Pixiecore](https://github.com/google/netboot/tree/master/pixiecore): an all-in-one tool for easy netbooting.

--- a/pixiecore/README.md
+++ b/pixiecore/README.md
@@ -1,12 +1,18 @@
 # Pixiecore
 
-Pixiecore is an all-in-one tool to manage network booting of
-machines. It can be used either as a simple tool for ad-hoc network
-boots, or as a building block of machine management infrastructure.
+Pixiecore is an tool to manage network booting of machines. It can be used
+for simple single shot network boots, or as a building block of machine
+management infrastructure.
 
-[![license](https://img.shields.io/github/license/google/netboot.svg?maxAge=2592000)](https://github.com/google/netboot/blob/master/LICENSE) [![Travis](https://img.shields.io/travis/google/netboot.svg?maxAge=2592000)](https://travis-ci.org/google/netboot)  ![api](https://img.shields.io/badge/api-unstable-red.svg) ![cli](https://img.shields.io/badge/cli-stable-green.svg) [![cli](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/go.universe.tf/netboot/pixiecore)
+[![license](https://img.shields.io/github/license/google/netboot.svg)](https://github.com/google/netboot/blob/master/LICENSE) ![api](https://img.shields.io/badge/api-unstable-red.svg) ![cli](https://img.shields.io/badge/cli-stable-green.svg) [![cli](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/go.universe.tf/netboot/pixiecore)
 
 ![Pixiecore UI](https://cdn.rawgit.com/google/netboot/master/pixiecore/pixiecore-ui.png)
+
+## TL;DR
+
+    pixiecore quick xyz --dhcp-no-bind
+
+Then try to boot another machine from the same network.
 
 ## Why?
 


### PR DESCRIPTION
By `user friendly` I mean that `pixiecore` program is referenced before developer libs, and instruction to run it is easily reachable. I've got a feeling that this can help me to increase stars from 699 ![image](https://user-images.githubusercontent.com/8781107/44006304-ecb4df32-9eb4-11e8-85d2-06e6aae01e22.png) significantly. :D

![image](https://user-images.githubusercontent.com/8781107/44006322-5c6644a6-9eb5-11e8-94e1-a211190cd021.png)

https://star-history.nepochataya.pp.ua/?repo=google%2Fnetboot