### PR TITLE
Add SSL Certificates

### DIFF
--- a/cmd/pixiecore/Dockerfile
+++ b/cmd/pixiecore/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:latest
 
+RUN apk add --no-cache ca-certificates
 ADD pixiecore /pixiecore
 ENTRYPOINT ["/pixiecore"]


### PR DESCRIPTION
The following error showed when using `pixiecore/pixiecore:master` container:

```
[HTTP] Error getting file "kernel"
https://boot.netboot.xyz/ipxe/netboot.xyz.lkrn: x509: failed to load system roots and no roots provided
```

Further research indicates this is because it is missing SSL certificates to validate the HTTP connection.
This commit adds a dependency on ca-certificates for the image to be complete