### PR TITLE
Allow to provide an external base64 encoded signing key

### DIFF
--- a/pixiecore/cli/v1compat.go
+++ b/pixiecore/cli/v1compat.go
@@ -73,8 +73,10 @@ func v1compatCLI() bool {
 			fatalf("cannot provide -cmdline with -api")
 		}
 
+		var key [32]byte
+
 		log.Printf("Starting Pixiecore in API mode, with server %s", *apiServer)
-		booter, err := pixiecore.APIBooter(*apiServer, *apiTimeout)
+		booter, err := pixiecore.APIBooter(*apiServer, *apiTimeout, key)
 		if err != nil {
 			fatalf("Failed to create API booter: %s", err)
 		}


### PR DESCRIPTION
I need to run several pixiecore instances (for a dhcp high availability purpose)
For this reason I need a way to bind the signing key an all instances to be able to check for valid nonces on whatever instance.

Thx.